### PR TITLE
OAuth utils: Fix no view props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raycast/utils",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Set of utilities to streamline building Raycast extensions",
   "author": "Raycast Technologies Ltd.",
   "homepage": "https://developers.raycast.com/utils-reference",

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -22,7 +22,7 @@
     },
     "..": {
       "name": "@raycast/utils",
-      "version": "1.10.1",
+      "version": "1.11.1",
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",

--- a/tests/package.json
+++ b/tests/package.json
@@ -114,11 +114,49 @@
       "mode": "view"
     },
     {
+      "name": "oauth-with-props",
+      "title": "OAuth with Props",
+      "subtitle": "Utils Smoke Tests",
+      "description": "Utils Smoke Tests",
+      "mode": "view",
+      "arguments": [
+        {
+          "name": "text",
+          "placeholder": "Text",
+          "type": "text",
+          "required": true
+        }
+      ]
+    },
+    {
       "name": "oauth-no-view",
       "title": "OAuth No View",
       "subtitle": "Utils Smoke Tests",
       "description": "Utils Smoke Tests",
-      "mode": "no-view"
+      "mode": "no-view",
+      "arguments": [
+        {
+          "name": "comment",
+          "placeholder": "Comment",
+          "type": "text",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "oauth-no-view-with-props",
+      "title": "OAuth No View with Props",
+      "subtitle": "Utils Smoke Tests",
+      "description": "Utils Smoke Tests",
+      "mode": "no-view",
+      "arguments": [
+        {
+          "name": "text",
+          "placeholder": "Text",
+          "type": "text",
+          "required": true
+        }
+      ]
     }
   ],
   "dependencies": {

--- a/tests/src/oauth-no-view-with-props.tsx
+++ b/tests/src/oauth-no-view-with-props.tsx
@@ -1,0 +1,16 @@
+import { LaunchProps, showHUD } from "@raycast/api";
+import { getAccessToken, withAccessToken, OAuthService } from "@raycast/utils";
+
+const linear = OAuthService.linear({
+  scope: "read write",
+  onAuthorize(params) {
+    console.log(params);
+  },
+});
+
+async function Command(props: LaunchProps<{ arguments: Arguments.OauthNoViewWithProps }>) {
+  const { token } = getAccessToken();
+  await showHUD(`${props.arguments.text} ${token}`);
+}
+
+export default withAccessToken(linear)(Command);

--- a/tests/src/oauth-with-props.tsx
+++ b/tests/src/oauth-with-props.tsx
@@ -1,0 +1,12 @@
+import { Detail, LaunchProps } from "@raycast/api";
+import { getAccessToken, withAccessToken, OAuthService } from "@raycast/utils";
+
+const github = OAuthService.github({
+  scope: "notifications repo read:org read:user read:project",
+});
+
+function AuthorizedComponent(props: LaunchProps<{ arguments: Arguments.OauthWithProps }>) {
+  return <Detail markdown={`## Access token\n\n${getAccessToken().token}\n\n## Argument\n\n${props.arguments.text}`} />;
+}
+
+export default withAccessToken(github)(AuthorizedComponent);


### PR DESCRIPTION
The props were not passed to `no-view` commands beforehand when used with `withAccessToken`. Now it does.