### PR TITLE
`usePromise`: Add `cursor` to `PaginationOptions`.

### DIFF
--- a/docs/utils-reference/react-hooks/useCachedPromise.md
+++ b/docs/utils-reference/react-hooks/useCachedPromise.md
@@ -353,10 +353,12 @@ An object passed to a `PaginatedPromise`, it has two properties:
 
 - `page`: 0-indexed, this it's incremented every time the promise resolves, and is reset whenever `revalidate()` is called.
 - `lastItem`: this is a copy of the last item in the `data` array from the last time the promise was executed. Provided for APIs that implement cursor-based pagination.
+- `cursor`: this is the `cursor` property returned after the previous execution of `PaginatedPromise`. Useful when working with APIs that provide the next cursor explicitly.
 
 ```ts
 export type PaginationOptions<T = any> = {
   page: number;
   lastItem?: T;
+  cursor?: any;
 };
 ```

--- a/docs/utils-reference/react-hooks/useFetch.md
+++ b/docs/utils-reference/react-hooks/useFetch.md
@@ -322,10 +322,12 @@ An object passed to a `PaginatedRequestInfo`, it has two properties:
 
 - `page`: 0-indexed, this it's incremented every time the promise resolves, and is reset whenever `revalidate()` is called.
 - `lastItem`: this is a copy of the last item in the `data` array from the last time the promise was executed. Provided for APIs that implement cursor-based pagination.
+- `cursor`: this is the `cursor` property returned after the previous execution of `PaginatedPromise`. Useful when working with APIs that provide the next cursor explicitly.
 
 ```ts
 export type PaginationOptions<T = any> = {
   page: number;
   lastItem?: T;
+  cursor?: any;
 };
 ```

--- a/docs/utils-reference/react-hooks/usePromise.md
+++ b/docs/utils-reference/react-hooks/usePromise.md
@@ -171,10 +171,10 @@ to
 ```ts
 const { isLoading, data, pagination } = usePromise(
   (searchText: string) =>
-    async ({ page, lastItem }) => {
-      const data = await getUsers(); // or any other asynchronous logic you need to perform
+    async ({ page, lastItem, cursor }) => {
+      const { data, nextCursor } = await getUsers(cursor); // or any other asynchronous logic you need to perform
       const hasMore = page < 50; //
-      return { data, hasMore };
+      return { data, hasMore, cursor: nextCursor };
     },
   [searchText],
 );
@@ -187,11 +187,13 @@ Another thing to notice is that the async function receives a [PaginationOptions
 {
   data: any[];
   hasMore: boolean;
+  cursor?: any;
 }
 ```
 
 Every time the promise resolves, the hook needs to figure out if it should paginate further, or if it should stop, and it uses `hasMore` for this.
 In addition to this, the hook also needs `data`, and needs it to be an array, because internally it appends it to a list, thus making sure the `data` that the hook _returns_ always contains the data for all of the pages that have been loaded so far.
+Additionally, you can also pass a `cursor` property, which will be included along with `page` and `lastItem` in the next pagination call.
 
 ### Full Example
 
@@ -288,10 +290,12 @@ An object passed to a `PaginatedPromise`, it has two properties:
 
 - `page`: 0-indexed, this it's incremented every time the promise resolves, and is reset whenever `revalidate()` is called.
 - `lastItem`: this is a copy of the last item in the `data` array from the last time the promise was executed. Provided for APIs that implement cursor-based pagination.
+- `cursor`: this is the `cursor` property returned after the previous execution of `PaginatedPromise`. Useful when working with APIs that provide the next cursor explicitly.
 
 ```ts
 export type PaginationOptions<T = any> = {
   page: number;
   lastItem?: T;
+  cursor?: any;
 };
 ```

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,11 +7,16 @@ export type PaginationOptions<T = any> = {
    * The last item from the previous page of results, useful for APIs implementing cursor-based pagination.
    */
   lastItem?: Flatten<T>;
+  /**
+   * Some APIs don't use the last returned item as a cursor, but instead provide the next cursor explicitly. In those cases,
+   * you can pass `cursor` along with `data` and `hasMore`, and it will be included in each pagination call.
+   */
+  cursor?: any;
 };
 export type FunctionReturningPromise<T extends any[] = any[], U = any> = (...args: T) => Promise<U>;
 export type FunctionReturningPaginatedPromise<T extends any[] = any[], U extends any[] = any[]> = (
   ...args: T
-) => (pagination: PaginationOptions<U>) => Promise<{ data: U; hasMore?: boolean }>;
+) => (pagination: PaginationOptions<U>) => Promise<{ data: U; hasMore?: boolean; cursor?: any }>;
 export type UnwrapReturn<T extends FunctionReturningPromise | FunctionReturningPaginatedPromise> =
   T extends FunctionReturningPromise
     ? Awaited<ReturnType<T>>

--- a/src/usePromise.ts
+++ b/src/usePromise.ts
@@ -204,8 +204,13 @@ export function usePromise<T extends FunctionReturningPromise | FunctionReturnin
         usePaginationRef.current = true;
         return promiseOrPaginatedPromise(paginationArgsRef.current).then(
           // @ts-expect-error too complicated for TS
-          ({ data, hasMore }: { data: UnwrapReturn<T>; hasMore: boolean }) => {
+          ({ data, hasMore, cursor }: { data: UnwrapReturn<T>; hasMore: boolean }) => {
             if (callId === lastCallId.current) {
+              if (paginationArgsRef.current) {
+                paginationArgsRef.current.cursor = cursor;
+                paginationArgsRef.current.lastItem = data?.[data.length - 1];
+              }
+
               if (latestOnData.current) {
                 latestOnData.current(data, paginationArgsRef.current);
               }
@@ -307,10 +312,7 @@ export function usePromise<T extends FunctionReturningPromise | FunctionReturnin
   );
 
   const onLoadMore = useCallback(() => {
-    paginationArgsRef.current = {
-      page: paginationArgsRef.current.page + 1,
-      lastItem: latestValue.current?.[latestValue.current.length - 1],
-    };
+    paginationArgsRef.current.page += 1;
     const args = (latestArgs.current || []) as Parameters<T>;
     callback(...args);
   }, [paginationArgsRef, latestValue, latestArgs, callback]);

--- a/src/usePromise.ts
+++ b/src/usePromise.ts
@@ -204,7 +204,7 @@ export function usePromise<T extends FunctionReturningPromise | FunctionReturnin
         usePaginationRef.current = true;
         return promiseOrPaginatedPromise(paginationArgsRef.current).then(
           // @ts-expect-error too complicated for TS
-          ({ data, hasMore, cursor }: { data: UnwrapReturn<T>; hasMore: boolean }) => {
+          ({ data, hasMore, cursor }: { data: UnwrapReturn<T>; hasMore: boolean; cursor?: any }) => {
             if (callId === lastCallId.current) {
               if (paginationArgsRef.current) {
                 paginationArgsRef.current.cursor = cursor;


### PR DESCRIPTION
While trying to implement cursor-based pagination, both @thomaslombart and I have run into limitations of `lastItem`. Specifically, some APIs don't rely on the last item as the cursor, but instead provide the cursor themselves. One example of this is [Sentry](https://docs.sentry.io/api/pagination/), which includes pagination info as part of the API response's `link` header.

To address this, I've added a new `PaginationOption`: `cursor`. This is passed to the pagination function, along with `page` and `lastItem`. To set it, the promise can return, in addition to `data` and `hasMore`, a `cursor` property.

