### PR TITLE
OAuth: Fix refresh token flow to log out user

### DIFF
--- a/docs/utils-reference/getting-started.md
+++ b/docs/utils-reference/getting-started.md
@@ -16,6 +16,10 @@ npm install --save @raycast/utils
 
 ## Changelog
 
+### v1.16.2
+
+- Fixed the refresh token flow to log out the user instead of throwing an error.
+
 ### v1.16.1
 
 - Fixed an issue where `bodyEncoding` wasn't properly used in OAuthService.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raycast/utils",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "description": "Set of utilities to streamline building Raycast extensions",
   "author": "Raycast Technologies Ltd.",
   "homepage": "https://developers.raycast.com/utils-reference",


### PR DESCRIPTION
Fixed the refresh token flow to log out the user instead of throwing an error.

![CleanShot 2024-07-11 at 11 59 41@2x](https://github.com/raycast/utils/assets/16003285/93f47ea4-d1a2-4fe9-9887-c6ccfea0687a)
