### PR TITLE
Fixes and doc addition for `failureToastOptions` in applicable hooks

### DIFF
--- a/docs/utils-reference/getting-started.md
+++ b/docs/utils-reference/getting-started.md
@@ -16,9 +16,13 @@ npm install --save @raycast/utils
 
 ## Changelog
 
+### v1.16.5
+
+- Fixed the bug where `failureToastOptions` did not apply for `useExec` and `useStreamJSON` hooks.
+
 ### v1.16.4
 
-- Avoid throwing an error when `useFetch` can't parse the `Content-Type` header of the response
+- Avoid throwing an error when `useFetch` can't parse the `Content-Type` header of the response.
 
 ### v1.16.3
 

--- a/docs/utils-reference/react-hooks/useAI.md
+++ b/docs/utils-reference/react-hooks/useAI.md
@@ -14,7 +14,8 @@ function useAI(
     execute?: boolean;
     onError?: (error: Error) => void;
     onData?: (data: T) => void;
-    onWillExecute?: (args: string[]) -> void;
+    onWillExecute?: (args: Parameters<T>) => void;
+    failureToastOptions?: Partial<Pick<Toast.Options, "title" | "primaryAction" | "message">>;
   }
 ): AsyncState<String> & {
   revalidate: () => void;
@@ -37,6 +38,7 @@ Including the [usePromise](./usePromise.md)'s options:
 - `options.onError` is a function called when an execution fails. By default, it will log the error and show a generic failure toast with an action to retry.
 - `options.onData` is a function called when an execution succeeds.
 - `options.onWillExecute` is a function called when an execution will start.
+- `options.failureToastOptions` are the options to customize the title, message, and primary action of the failure toast.
 
 ### Return
 

--- a/docs/utils-reference/react-hooks/useCachedPromise.md
+++ b/docs/utils-reference/react-hooks/useCachedPromise.md
@@ -27,6 +27,7 @@ function useCachedPromise<T, U>(
     onError?: (error: Error) => void;
     onData?: (data: Result<T>) => void;
     onWillExecute?: (args: Parameters<T>) => void;
+    failureToastOptions?: Partial<Pick<Toast.Options, "title" | "primaryAction" | "message">>;
   },
 ): AsyncState<Result<T>> & {
   revalidate: () => void;
@@ -54,6 +55,7 @@ Including the [usePromise](./usePromise.md)'s options:
 - `options.onError` is a function called when an execution fails. By default, it will log the error and show a generic failure toast with an action to retry.
 - `options.onData` is a function called when an execution succeeds.
 - `options.onWillExecute` is a function called when an execution will start.
+- `options.failureToastOptions` are the options to customize the title, message, and primary action of the failure toast.
 
 ### Return
 

--- a/docs/utils-reference/react-hooks/useExec.md
+++ b/docs/utils-reference/react-hooks/useExec.md
@@ -30,7 +30,8 @@ function useExec<T, U>(
     execute?: boolean;
     onError?: (error: Error) => void;
     onData?: (data: T) => void;
-    onWillExecute?: (args: string[]) -> void;
+    onWillExecute?: (args: string[]) => void;
+    failureToastOptions?: Partial<Pick<Toast.Options, "title" | "primaryAction" | "message">>;
   }
 ): AsyncState<T> & {
   revalidate: () => void;
@@ -61,7 +62,8 @@ function useExec<T, U>(
     execute?: boolean;
     onError?: (error: Error) => void;
     onData?: (data: T) => void;
-    onWillExecute?: (args: string[]) -> void;
+    onWillExecute?: (args: string[]) => void;
+    failureToastOptions?: Partial<Pick<Toast.Options, "title" | "primaryAction" | "message">>;
   }
 ): AsyncState<T> & {
   revalidate: () => void;
@@ -110,6 +112,7 @@ Including the [usePromise](./usePromise.md)'s options:
 - `options.onError` is a function called when an execution fails. By default, it will log the error and show a generic failure toast with an action to retry.
 - `options.onData` is a function called when an execution succeeds.
 - `options.onWillExecute` is a function called when an execution will start.
+- `options.failureToastOptions` are the options to customize the title, message, and primary action of the failure toast.
 
 ### Return
 

--- a/docs/utils-reference/react-hooks/useFetch.md
+++ b/docs/utils-reference/react-hooks/useFetch.md
@@ -20,6 +20,7 @@ export function useFetch<V, U, T = V>(
     onError?: (error: Error) => void;
     onData?: (data: T) => void;
     onWillExecute?: (args: [string, RequestInit]) => void;
+    failureToastOptions?: Partial<Pick<Toast.Options, "title" | "primaryAction" | "message">>;
   },
 ): AsyncState<T> & {
   revalidate: () => void;
@@ -51,6 +52,7 @@ Including the [usePromise](./usePromise.md)'s options:
 - `options.onError` is a function called when an execution fails. By default, it will log the error and show a generic failure toast with an action to retry.
 - `options.onData` is a function called when an execution succeeds.
 - `options.onWillExecute` is a function called when an execution will start.
+- `options.failureToastOptions` are the options to customize the title, message, and primary action of the failure toast.
 
 ### Return
 

--- a/docs/utils-reference/react-hooks/usePromise.md
+++ b/docs/utils-reference/react-hooks/usePromise.md
@@ -20,6 +20,7 @@ function usePromise<T>(
     onError?: (error: Error) => void;
     onData?: (data: Result<T>) => void;
     onWillExecute?: (args: Parameters<T>) => void;
+    failureToastOptions?: Partial<Pick<Toast.Options, "title" | "primaryAction" | "message">>;
   },
 ): AsyncState<Result<T>> & {
   revalidate: () => void;
@@ -39,6 +40,7 @@ With a few options:
 - `options.onError` is a function called when an execution fails. By default, it will log the error and show a generic failure toast with an action to retry.
 - `options.onData` is a function called when an execution succeeds.
 - `options.onWillExecute` is a function called when an execution will start.
+- `options.failureToastOptions` are the options to customize the title, message, and primary action of the failure toast.
 
 ### Returns
 

--- a/docs/utils-reference/react-hooks/useSQL.md
+++ b/docs/utils-reference/react-hooks/useSQL.md
@@ -13,7 +13,8 @@ function useSQL<T>(
     execute?: boolean;
     onError?: (error: Error) => void;
     onData?: (data: T) => void;
-    onWillExecute?: (args: string[]) -> void;
+    onWillExecute?: (args: string[]) => void;
+    failureToastOptions?: Partial<Pick<Toast.Options, "title" | "primaryAction" | "message">>;
   }
 ): AsyncState<T> & {
   revalidate: () => void;
@@ -37,6 +38,7 @@ Including the [usePromise](./usePromise.md)'s options:
 - `options.onError` is a function called when an execution fails. By default, it will log the error and show a generic failure toast with an action to retry.
 - `options.onData` is a function called when an execution succeeds.
 - `options.onWillExecute` is a function called when an execution will start.
+- `options.failureToastOptions` are the options to customize the title, message, and primary action of the failure toast.
 
 ### Return
 

--- a/docs/utils-reference/react-hooks/useStreamJSON.md
+++ b/docs/utils-reference/react-hooks/useStreamJSON.md
@@ -17,6 +17,7 @@ export function useStreamJSON<T, U>(
     onError?: (error: Error) => void;
     onData?: (data: T) => void;
     onWillExecute?: (args: [string, RequestInit]) => void;
+    failureToastOptions?: Partial<Pick<Toast.Options, "title" | "primaryAction" | "message">>;
   },
 ): AsyncState<Result<T>> & {
   revalidate: () => void;
@@ -48,7 +49,8 @@ Including the [usePromise](./usePromise.md)'s options:
 - `options.execute` is a boolean to indicate whether to actually execute the function or not. This is useful for cases where one of the function's arguments depends on something that might not be available right away (for example, depends on some user inputs). Because React requires every hook to be defined on the render, this flag enables you to define the hook right away but wait until you have all the arguments ready to execute the function.
 - `options.onError` is a function called when an execution fails. By default, it will log the error and show a generic failure toast with an action to retry.
 - `options.onData` is a function called when an execution succeeds.
-- `options.onWillExecute` is a function called when an execution will start..
+- `options.onWillExecute` is a function called when an execution will start.
+- `options.failureToastOptions` are the options to customize the title, message, and primary action of the failure toast.
 
 ### Return
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raycast/utils",
-  "version": "1.16.4",
+  "version": "1.16.5",
   "description": "Set of utilities to streamline building Raycast extensions",
   "author": "Raycast Technologies Ltd.",
   "homepage": "https://developers.raycast.com/utils-reference",

--- a/src/useExec.ts
+++ b/src/useExec.ts
@@ -170,7 +170,7 @@ export function useExec<T, U = undefined>(
   } & ExecOptions &
     ExecCachedPromiseOptions<T, U>,
 ): UseCachedPromiseReturnType<T, U> {
-  const { parseOutput, input, onData, onWillExecute, initialData, execute, keepPreviousData, onError, ...execOptions } =
+  const { parseOutput, input, onData, onWillExecute, initialData, execute, keepPreviousData, onError, failureToastOptions, ...execOptions } =
     Array.isArray(optionsOrArgs) ? options || {} : optionsOrArgs || {};
 
   const useCachedPromiseOptions: ExecCachedPromiseOptions<T, U> = {
@@ -180,6 +180,7 @@ export function useExec<T, U = undefined>(
     onError,
     onData,
     onWillExecute,
+    failureToastOptions,
   };
 
   const abortable = useRef<AbortController>();

--- a/src/useStreamJSON.ts
+++ b/src/useStreamJSON.ts
@@ -391,6 +391,7 @@ export function useStreamJSON<T, U extends any[] = any[]>(
     onError,
     onData,
     onWillExecute,
+    failureToastOptions,
     dataPath,
     filter,
     transform,
@@ -407,6 +408,7 @@ export function useStreamJSON<T, U extends any[] = any[]>(
     onError,
     onData,
     onWillExecute,
+    failureToastOptions,
   };
 
   const generatorRef = useRef<AsyncGenerator<T extends unknown[] ? T : T[]> | null>(null);


### PR DESCRIPTION
* `failureToastOptions` are now applied to useExec and useStreamJSON hooks
* docs: add failureToastOptions to all applicable hooks docs
* closes https://github.com/raycast/utils/issues/39