### PR TITLE
Add executeSQL function

### DIFF
--- a/docs/utils-reference/SUMMARY.md
+++ b/docs/utils-reference/SUMMARY.md
@@ -5,6 +5,7 @@
   - [runAppleScript](utils-reference/functions/runAppleScript.md)
   - [showFailureToast](utils-reference/functions/showFailureToast.md)
   - [createDeeplink](utils-reference/functions/createDeeplink.md)
+  - [executeSQL](utils-reference/functions/executeSQL.md)
 - [Icons](utils-reference/icons/README.md)
   - [getAvatarIcon](utils-reference/icons/getAvatarIcon.md)
   - [getFavicon](utils-reference/icons/getFavicon.md)

--- a/docs/utils-reference/functions/executeSQL.md
+++ b/docs/utils-reference/functions/executeSQL.md
@@ -1,0 +1,46 @@
+# `executeSQL`
+
+A function that executes a SQL query on a local SQLite database and returns the query result in JSON format.
+
+## Signature
+
+```ts
+function executeSQL<T = unknown>(databasePath: string, query: string): Promise<T[] | undefined>
+```
+
+### Arguments
+
+- `databasePath` is the path to the local SQL database.
+- `query` is the SQL query to run on the database.
+
+### Return
+
+Returns a `Promise` that resolves to an array of objects representing the query results, or `undefined` if an error occurs.
+
+## Example
+
+```typescript
+import { closeMainWindow, Clipboard } from "@raycast/api";
+import { executeSQL } from "@raycast/utils";
+
+type Message = { body: string; code: string };
+
+const DB_PATH = "/path/to/chat.db";
+
+export default async function Command() {
+  const query = `
+    SELECT body, code
+    FROM message
+    ORDER BY date DESC
+    LIMIT 1;
+  `;
+
+  const messages = await executeSQL<Message>(DB_PATH, query);
+
+  if (messages && messages.length > 0) {
+    const latestCode = messages[0].code;
+    await Clipboard.paste(latestCode);
+    await closeMainWindow();
+  }
+}
+```

--- a/docs/utils-reference/functions/executeSQL.md
+++ b/docs/utils-reference/functions/executeSQL.md
@@ -5,7 +5,7 @@ A function that executes a SQL query on a local SQLite database and returns the 
 ## Signature
 
 ```ts
-function executeSQL<T = unknown>(databasePath: string, query: string): Promise<T[] | undefined>
+function executeSQL<T = unknown>(databasePath: string, query: string): Promise<T[]>
 ```
 
 ### Arguments
@@ -15,7 +15,7 @@ function executeSQL<T = unknown>(databasePath: string, query: string): Promise<T
 
 ### Return
 
-Returns a `Promise` that resolves to an array of objects representing the query results, or `undefined` if an error occurs.
+Returns a `Promise` that resolves to an array of objects representing the query results.
 
 ## Example
 
@@ -37,7 +37,7 @@ export default async function Command() {
 
   const messages = await executeSQL<Message>(DB_PATH, query);
 
-  if (messages && messages.length > 0) {
+  if (messages.length > 0) {
     const latestCode = messages[0].code;
     await Clipboard.paste(latestCode);
     await closeMainWindow();

--- a/docs/utils-reference/getting-started.md
+++ b/docs/utils-reference/getting-started.md
@@ -16,6 +16,10 @@ npm install --save @raycast/utils
 
 ## Changelog
 
+### v1.18.0
+
+- Add a new [`executeSQL](./functions/executeSQL.md) function.
+
 ### v1.17.0
 
 - Add a new [`createDeeplink`](./functions/createDeeplink.md) function.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raycast/utils",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Set of utilities to streamline building Raycast extensions",
   "author": "Raycast Technologies Ltd.",
   "homepage": "https://developers.raycast.com/utils-reference",

--- a/src/executeSQL.ts
+++ b/src/executeSQL.ts
@@ -1,0 +1,49 @@
+import { open } from "@raycast/api";
+import { showFailureToast } from "./showFailureToast";
+import { baseExecuteSQL, getSystemPreferencesInfo, isPermissionError } from "./sql-utils";
+
+/**
+ * Executes a SQL query on a local SQLite database and returns the query result in JSON format.
+ *
+ * @param databasePath - The path to the SQLite database file.
+ * @param query - The SQL query to execute.
+ * @returns A Promise that resolves to an array of objects representing the query results.
+ *
+ * @example
+ * ```typescript
+ * import { executeSQL } from "./executeSQL";
+ *
+ * type User = { id: number, name: string };
+ *
+ * const dbPath = "/path/to/database.sqlite";
+ * const query = "SELECT id, name FROM users WHERE age > 18";
+ *
+ * try {
+ *   const results = await executeSQL<User>(dbPath, query);
+ *   console.log(results);
+ * } catch (error) {
+ *   console.error("Error executing SQL:", error);
+ * }
+ * ```
+ */
+export async function executeSQL<T = unknown>(databasePath: string, query: string) {
+  try {
+    return await baseExecuteSQL<T>(databasePath, query);
+  } catch (error) {
+    if (isPermissionError(error)) {
+      const { preferencesName, action } = getSystemPreferencesInfo();
+      await showFailureToast(error, {
+        title: "Raycast needs full disk access",
+        message: `You can revert this access in "${preferencesName}" whenever you want.`,
+        primaryAction: {
+          title: action.title,
+          onAction() {
+            open(action.target);
+          },
+        },
+      });
+    } else {
+      await showFailureToast(error, { title: "Cannot execute SQL" });
+    }
+  }
+}

--- a/src/executeSQL.ts
+++ b/src/executeSQL.ts
@@ -1,6 +1,4 @@
-import { open } from "@raycast/api";
-import { showFailureToast } from "./showFailureToast";
-import { baseExecuteSQL, getSystemPreferencesInfo, isPermissionError } from "./sql-utils";
+import { baseExecuteSQL } from "./sql-utils";
 
 /**
  * Executes a SQL query on a local SQLite database and returns the query result in JSON format.
@@ -11,39 +9,26 @@ import { baseExecuteSQL, getSystemPreferencesInfo, isPermissionError } from "./s
  *
  * @example
  * ```typescript
- * import { executeSQL } from "./executeSQL";
+ * import { closeMainWindow, Clipboard } from "@raycast/api";
+ * import { executeSQL } from "@raycast/utils";
  *
- * type User = { id: number, name: string };
+ * type Message = { body: string; code: string };
  *
- * const dbPath = "/path/to/database.sqlite";
- * const query = "SELECT id, name FROM users WHERE age > 18";
+ * const DB_PATH = "/path/to/chat.db";
  *
- * try {
- *   const results = await executeSQL<User>(dbPath, query);
- *   console.log(results);
- * } catch (error) {
- *   console.error("Error executing SQL:", error);
+ * export default async function Command() {
+ *   const query = `SELECT body, code FROM ...`
+ *
+ *   const messages = await executeSQL<Message>(DB_PATH, query);
+ *
+ *   if (messages.length > 0) {
+ *     const latestCode = messages[0].code;
+ *     await Clipboard.paste(latestCode);
+ *     await closeMainWindow();
+ *   }
  * }
  * ```
  */
-export async function executeSQL<T = unknown>(databasePath: string, query: string) {
-  try {
-    return await baseExecuteSQL<T>(databasePath, query);
-  } catch (error) {
-    if (isPermissionError(error)) {
-      const { preferencesName, action } = getSystemPreferencesInfo();
-      await showFailureToast(error, {
-        title: "Raycast needs full disk access",
-        message: `You can revert this access in "${preferencesName}" whenever you want.`,
-        primaryAction: {
-          title: action.title,
-          onAction() {
-            open(action.target);
-          },
-        },
-      });
-    } else {
-      await showFailureToast(error, { title: "Cannot execute SQL" });
-    }
-  }
+export function executeSQL<T = unknown>(databasePath: string, query: string) {
+  return baseExecuteSQL<T>(databasePath, query);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,10 +14,10 @@ export * from "./icon";
 
 export * from "./oauth";
 
+export * from "./createDeeplink";
+export * from "./executeSQL";
 export * from "./run-applescript";
 export * from "./showFailureToast";
-
-export * from "./createDeeplink";
 
 export type { AsyncState, MutatePromise } from "./types";
 export type { Response } from "cross-fetch";

--- a/src/sql-utils.ts
+++ b/src/sql-utils.ts
@@ -17,21 +17,6 @@ export function isPermissionError(error: unknown): error is PermissionError {
   return error instanceof Error && error.name === "PermissionError";
 }
 
-export function getSystemPreferencesInfo() {
-  const macosVenturaAndLater = parseInt(os.release().split(".")[0]) >= 22;
-  const preferencesName = macosVenturaAndLater ? "Settings" : "Preferences";
-  const action = macosVenturaAndLater
-    ? {
-        title: "Open System Settings -> Privacy",
-        target: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles",
-      }
-    : {
-        title: "Open System Preferences -> Security",
-        target: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles",
-      };
-  return { preferencesName, action };
-}
-
 export async function baseExecuteSQL<T = unknown>(
   databasePath: string,
   query: string,

--- a/src/sql-utils.ts
+++ b/src/sql-utils.ts
@@ -1,0 +1,106 @@
+import { existsSync } from "node:fs";
+import { copyFile, mkdir, writeFile } from "node:fs/promises";
+import os from "node:os";
+import childProcess from "node:child_process";
+import path from "node:path";
+import { getSpawnedPromise, getSpawnedResult } from "./exec-utils";
+import { hash } from "./helpers";
+
+export class PermissionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PermissionError";
+  }
+}
+
+export function isPermissionError(error: unknown): error is PermissionError {
+  return error instanceof Error && error.name === "PermissionError";
+}
+
+export function getSystemPreferencesInfo() {
+  const macosVenturaAndLater = parseInt(os.release().split(".")[0]) >= 22;
+  const preferencesName = macosVenturaAndLater ? "Settings" : "Preferences";
+  const action = macosVenturaAndLater
+    ? {
+        title: "Open System Settings -> Privacy",
+        target: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles",
+      }
+    : {
+        title: "Open System Preferences -> Security",
+        target: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles",
+      };
+  return { preferencesName, action };
+}
+
+export async function baseExecuteSQL<T = unknown>(
+  databasePath: string,
+  query: string,
+  options?: {
+    signal?: AbortSignal;
+  },
+): Promise<T[]> {
+  if (!existsSync(databasePath)) {
+    throw new Error("The database does not exist");
+  }
+
+  const abortSignal = options?.signal;
+  let workaroundCopiedDb: string | undefined;
+
+  let spawned = childProcess.spawn("sqlite3", ["--json", "--readonly", databasePath, query], { signal: abortSignal });
+  let spawnedPromise = getSpawnedPromise(spawned);
+  let [{ error, exitCode, signal }, stdoutResult, stderrResult] = await getSpawnedResult<string>(
+    spawned,
+    { encoding: "utf-8" },
+    spawnedPromise,
+  );
+  checkAborted(abortSignal);
+
+  if (stderrResult.match("(5)") || stderrResult.match("(14)")) {
+    // That means that the DB is busy because of another app is locking it
+    // This happens when Chrome or Arc is opened: they lock the History db.
+    // As an ugly workaround, we duplicate the file and read that instead
+    // (with vfs unix - none to just not care about locks)
+    if (!workaroundCopiedDb) {
+      const tempFolder = path.join(os.tmpdir(), "useSQL", hash(databasePath));
+      await mkdir(tempFolder, { recursive: true });
+      checkAborted(abortSignal);
+
+      workaroundCopiedDb = path.join(tempFolder, "db.db");
+      await copyFile(databasePath, workaroundCopiedDb);
+
+      await writeFile(workaroundCopiedDb + "-shm", "");
+      await writeFile(workaroundCopiedDb + "-wal", "");
+
+      checkAborted(abortSignal);
+    }
+
+    spawned = childProcess.spawn("sqlite3", ["--json", "--readonly", "--vfs", "unix-none", workaroundCopiedDb, query], {
+      signal: abortSignal,
+    });
+    spawnedPromise = getSpawnedPromise(spawned);
+    [{ error, exitCode, signal }, stdoutResult, stderrResult] = await getSpawnedResult<string>(
+      spawned,
+      { encoding: "utf-8" },
+      spawnedPromise,
+    );
+    checkAborted(abortSignal);
+  }
+
+  if (error || exitCode !== 0 || signal !== null) {
+    if (stderrResult.includes("authorization denied")) {
+      throw new PermissionError("You do not have permission to access the database.");
+    } else {
+      throw new Error(stderrResult || "Unknown error");
+    }
+  }
+
+  return JSON.parse(stdoutResult.trim() || "[]") as T[];
+}
+
+function checkAborted(signal?: AbortSignal) {
+  if (signal?.aborted) {
+    const error = new Error("aborted");
+    error.name = "AbortError";
+    throw error;
+  }
+}

--- a/src/useSQL.tsx
+++ b/src/useSQL.tsx
@@ -1,15 +1,10 @@
-import { List, ActionPanel, Action, environment, MenuBarExtra, Icon, open, LaunchType } from "@raycast/api";
+import { List, MenuBarExtra, Icon, open, LaunchType, environment, ActionPanel, Action } from "@raycast/api";
 import { existsSync } from "node:fs";
-import { copyFile, mkdir, writeFile } from "node:fs/promises";
-import os from "node:os";
-import childProcess from "node:child_process";
-import path from "node:path";
 import { useRef, useState, useCallback, useMemo } from "react";
 import { usePromise, PromiseOptions } from "./usePromise";
 import { useLatest } from "./useLatest";
-import { getSpawnedPromise, getSpawnedResult } from "./exec-utils";
 import { showFailureToast } from "./showFailureToast";
-import { hash } from "./helpers";
+import { baseExecuteSQL, PermissionError, isPermissionError, getSystemPreferencesInfo } from "./sql-utils";
 
 /**
  * Executes a query on a local SQL database and returns the {@link AsyncState} corresponding to the query of the command. The last value will be kept between command runs.
@@ -88,62 +83,10 @@ export function useSQL<T = unknown>(
     if (!existsSync(databasePath)) {
       throw new Error("The database does not exist");
     }
-    let workaroundCopiedDb: string | undefined = undefined;
 
     return async (databasePath: string, query: string) => {
       const abortSignal = abortable.current?.signal;
-      const spawned = childProcess.spawn("sqlite3", ["--json", "--readonly", databasePath, query], {
-        signal: abortSignal,
-      });
-      const spawnedPromise = getSpawnedPromise(spawned);
-      let [{ error, exitCode, signal }, stdoutResult, stderrResult] = await getSpawnedResult<string>(
-        spawned,
-        { encoding: "utf-8" },
-        spawnedPromise,
-      );
-
-      checkAborted(abortSignal);
-
-      if (stderrResult.match("(5)") || stderrResult.match("(14)")) {
-        // That means that the DB is busy because of another app is locking it
-        // This happens when Chrome or Arc is opened: they lock the History db.
-        // As an ugly workaround, we duplicate the file and read that instead
-        // (with vfs unix - none to just not care about locks)
-        if (!workaroundCopiedDb) {
-          const tempFolder = path.join(os.tmpdir(), "useSQL", hash(databasePath));
-          await mkdir(tempFolder, { recursive: true });
-          checkAborted(abortSignal);
-
-          workaroundCopiedDb = path.join(tempFolder, "db.db");
-          await copyFile(databasePath, workaroundCopiedDb);
-
-          // needed for certain db
-          await writeFile(workaroundCopiedDb + "-shm", "");
-          await writeFile(workaroundCopiedDb + "-wal", "");
-
-          checkAborted(abortSignal);
-        }
-        const spawned = childProcess.spawn(
-          "sqlite3",
-          ["--json", "--readonly", "--vfs", "unix-none", workaroundCopiedDb, query],
-          {
-            signal: abortSignal,
-          },
-        );
-        const spawnedPromise = getSpawnedPromise(spawned);
-        [{ error, exitCode, signal }, stdoutResult, stderrResult] = await getSpawnedResult<string>(
-          spawned,
-          { encoding: "utf-8" },
-          spawnedPromise,
-        );
-        checkAborted(abortSignal);
-      }
-
-      if (error || exitCode !== 0 || signal !== null) {
-        throw new Error(stderrResult);
-      }
-
-      return JSON.parse(stdoutResult.trim() || "[]") as T[];
+      return baseExecuteSQL<T>(databasePath, query, { signal: abortSignal });
     };
   }, [databasePath]);
 
@@ -153,42 +96,20 @@ export function useSQL<T = unknown>(
   };
 }
 
-class PermissionError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "PermissionError";
-  }
-}
-
-function isPermissionError(error: unknown) {
-  return error instanceof Error && error.name === "PermissionError";
-}
-
-const macosVenturaAndLater = parseInt(os.release().split(".")[0]) >= 22;
-const preferencesString = macosVenturaAndLater ? "Settings" : "Preferences";
-
 function PermissionErrorScreen(props: { priming?: string }) {
-  const action = macosVenturaAndLater
-    ? {
-        title: "Open System Settings -> Privacy",
-        target: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles",
-      }
-    : {
-        title: "Open System Preferences -> Security",
-        target: "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles",
-      };
+  const { preferencesName, action } = getSystemPreferencesInfo();
 
   if (environment.commandMode === "menu-bar") {
     return (
       <MenuBarExtra icon={Icon.Warning} title={environment.commandName}>
         <MenuBarExtra.Item
           title="Raycast needs full disk access"
-          tooltip={`You can revert this access in ${preferencesString} whenever you want`}
+          tooltip={`You can revert this access in ${preferencesName} whenever you want`}
         />
         {props.priming ? (
           <MenuBarExtra.Item
             title={props.priming}
-            tooltip={`You can revert this access in ${preferencesString} whenever you want`}
+            tooltip={`You can revert this access in ${preferencesName} whenever you want`}
           />
         ) : null}
         <MenuBarExtra.Separator />
@@ -209,7 +130,7 @@ function PermissionErrorScreen(props: { priming?: string }) {
         title="Raycast needs full disk access."
         description={`${
           props.priming ? props.priming + "\n" : ""
-        }You can revert this access in ${preferencesString} whenever you want.`}
+        }You can revert this access in ${preferencesName} whenever you want.`}
         actions={
           <ActionPanel>
             <Action.Open {...action} />
@@ -218,12 +139,4 @@ function PermissionErrorScreen(props: { priming?: string }) {
       />
     </List>
   );
-}
-
-function checkAborted(signal?: AbortSignal) {
-  if (signal?.aborted) {
-    const error = new Error("aborted");
-    error.name = "AbortError";
-    throw error;
-  }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -107,8 +107,15 @@
       "mode": "view"
     },
     {
-      "name": "sql",
+      "name": "use-sql",
       "title": "useSQL",
+      "subtitle": "Utils Smoke Tests",
+      "description": "Utils Smoke Tests",
+      "mode": "view"
+    },
+    {
+      "name": "execute-sql",
+      "title": "executeSQL",
       "subtitle": "Utils Smoke Tests",
       "description": "Utils Smoke Tests",
       "mode": "view"

--- a/tests/src/execute-sql.tsx
+++ b/tests/src/execute-sql.tsx
@@ -1,7 +1,7 @@
-import { useSQL } from "@raycast/utils";
+import { List } from "@raycast/api";
 import { resolve } from "path";
 import { homedir } from "os";
-import { List } from "@raycast/api";
+import { usePromise, executeSQL } from "@raycast/utils";
 
 const NOTES_DB = resolve(homedir(), "Library/Group Containers/group.com.apple.notes/NoteStore.sqlite");
 const notesQuery = `
@@ -29,6 +29,7 @@ const notesQuery = `
     )
     ORDER BY modDate DESC
   `;
+
 type NoteItem = {
   id: string;
   UUID: string;
@@ -37,11 +38,10 @@ type NoteItem = {
 };
 
 export default function Command() {
-  const { isLoading, data, permissionView } = useSQL<NoteItem>(NOTES_DB, notesQuery);
-
-  if (permissionView) {
-    return permissionView;
-  }
+  const { isLoading, data } = usePromise(async () => {
+    const result = await executeSQL<NoteItem>(NOTES_DB, notesQuery);
+    return result || [];
+  });
 
   return (
     <List isLoading={isLoading}>

--- a/tests/src/use-sql.tsx
+++ b/tests/src/use-sql.tsx
@@ -1,0 +1,54 @@
+import { useSQL } from "@raycast/utils";
+import { resolve } from "path";
+import { homedir } from "os";
+import { List } from "@raycast/api";
+
+const NOTES_DB = resolve(homedir(), "Library/Group Containers/group.com.apple.notes/NoteStore.sqlite");
+const notesQuery = `
+    SELECT
+        'x-coredata://' || z_uuid || '/ICNote/p' || xcoreDataID AS id,
+        noteTitle AS title,
+        datetime(modDate + 978307200, 'unixepoch') AS modifiedAt,
+        UUID as UUID
+    FROM (
+        SELECT
+            c.ztitle1 AS noteTitle,
+            c.zmodificationdate1 AS modDate,
+            c.z_pk AS xcoredataID,
+            c.zidentifier AS UUID
+        FROM
+            ziccloudsyncingobject AS c
+        WHERE
+            noteTitle IS NOT NULL AND
+            modDate IS NOT NULL AND
+            xcoredataID IS NOT NULL AND
+            c.zmarkedfordeletion != 1
+    ) AS notes
+    LEFT JOIN (
+        SELECT z_uuid FROM z_metadata
+    )
+    ORDER BY modDate DESC
+  `;
+
+type NoteItem = {
+  id: string;
+  UUID: string;
+  title: string;
+  modifiedAt?: Date;
+};
+
+export default function Command() {
+  const { isLoading, data, permissionView } = useSQL<NoteItem>(NOTES_DB, notesQuery);
+
+  if (permissionView) {
+    return permissionView;
+  }
+
+  return (
+    <List isLoading={isLoading}>
+      {(data || []).map((item) => (
+        <List.Item key={item.id} title={item.title} />
+      ))}
+    </List>
+  );
+}


### PR DESCRIPTION
Add `executeSQL` which proves to be handy when needing to run a SQL query in environments where a hook can't be used such as `no-view` commands.