### PR TITLE
API: Add new util that allows caching of functions

### DIFF
--- a/docs/utils-reference/SUMMARY.md
+++ b/docs/utils-reference/SUMMARY.md
@@ -6,6 +6,7 @@
   - [showFailureToast](utils-reference/functions/showFailureToast.md)
   - [createDeeplink](utils-reference/functions/createDeeplink.md)
   - [executeSQL](utils-reference/functions/executeSQL.md)
+  - [withCache](utils-reference/functions/withCache.md)
 - [Icons](utils-reference/icons/README.md)
   - [getAvatarIcon](utils-reference/icons/getAvatarIcon.md)
   - [getFavicon](utils-reference/icons/getFavicon.md)

--- a/docs/utils-reference/functions/withCache.md
+++ b/docs/utils-reference/functions/withCache.md
@@ -1,0 +1,43 @@
+# `withCache`
+
+Higher-order function which wraps a function with caching functionality using Raycast's Cache API.
+Allows for caching of expensive functions like paginated API calls that rarely change.
+
+## Signature
+
+```tsx
+function withCache<Fn extends (...args: any) => Promise<any>>(
+  fn: Fn,
+  options?: {
+    validate?: (data: Awaited<ReturnType<Fn>>) => boolean;
+    maxAge?: number;
+  },
+): Fn & { clearCache: () => void };
+```
+
+### Arguments
+
+`options` is an object containing:
+
+- `options.validate`: an optional function that receives the cached data and returns a boolean depending on whether the data is still valid or not.
+- `options.maxAge`: Maximum age of cached data in milliseconds after which the data will be considered invalid
+
+### Return
+
+Returns the wrapped function
+
+## Example
+
+```tsx
+import { withCache } from "@raycast/utils";
+
+function fetchExpensiveData(query) {
+  // ...
+}
+
+const cachedFunction = withCache(fetchExpensiveData, {
+  maxAge: 5 * 60 * 1000, // Cache for 5 minutes
+});
+
+const result = await cachedFunction(query);
+```

--- a/docs/utils-reference/getting-started.md
+++ b/docs/utils-reference/getting-started.md
@@ -16,6 +16,10 @@ npm install --save @raycast/utils
 
 ## Changelog
 
+### v1.19.0
+
+- Add a new [`withCache`](./functions/withCache.md) function.
+
 ### v1.18.1
 
 - Fixed an issue where setting `timeout` to `0` in `runAppleScript` would not work.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@raycast/utils",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@raycast/utils",
-      "version": "1.18.1",
+      "version": "1.19.0",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@raycast/utils",
-  "version": "1.17.0",
+  "version": "1.18.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@raycast/utils",
-      "version": "1.17.0",
+      "version": "1.18.1",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raycast/utils",
-  "version": "1.18.1",
+  "version": "1.19.0",
   "description": "Set of utilities to streamline building Raycast extensions",
   "author": "Raycast Technologies Ltd.",
   "homepage": "https://developers.raycast.com/utils-reference",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -3,50 +3,64 @@ import { hash, replacer, reviver } from "./helpers";
 
 /**
  * Wraps a function with caching functionality using Raycast's Cache API.
- * Allows for caching of expensive functions like paginated API calls.
+ * Allows for caching of expensive functions like paginated API calls that rarely change.
  *
  * @param fn - The async function to cache results from
  * @param options - Optional configuration for the cache behavior
- * @param options.key - Custom cache key (defaults to stringified function)
  * @param options.validate - Optional validation function for cached data
  * @param options.maxAge - Maximum age of cached data in milliseconds
- * @param options.namespace - Optional namespace for the cache
- * @returns The result of the function, either from cache or fresh execution
+ * @returns An async function that returns the result of the function, either from cache or fresh execution
  *
  * @example
  * ```ts
- * const data = await withCache(
- *   async () => fetchExpensiveData(),
- *   { maxAge: 5 * 60 * 1000 } // Cache for 5 minutes
- * );
+ * const cachedFunction = withCache(fetchExpensiveData, {
+ *   maxAge: 5 * 60 * 1000 // Cache for 5 minutes
+ * });
+ *
+ * const result = await cachedFunction(query);
  * ```
  */
-export async function withCache<T>(
-  fn: () => Promise<T>,
-  options?: { key?: string; validate?: (data: T) => boolean; maxAge?: number; namespace?: string },
-): Promise<T> {
-  const cache = new Cache({ namespace: options?.namespace });
+export function withCache<Fn extends (...args: any) => Promise<any>>(
+  fn: Fn,
+  options?: {
+    /** function that receives the cached data and returns a boolean depending on whether the data is still valid or not. */
+    validate?: (data: Awaited<ReturnType<Fn>>) => boolean;
+    /** Maximum age of cached data in milliseconds after which the data will be considered invalid */
+    maxAge?: number;
+  },
+): Fn & { clearCache: () => void } {
+  const cache = new Cache({ namespace: hash(fn) });
 
-  const key = options?.key ?? hash(fn);
-  const cached = cache.get(key);
-  if (cached) {
-    const { data, timestamp } = JSON.parse(cached, reviver);
-    const isExpired = options?.maxAge && Date.now() - timestamp > options.maxAge;
-    if (!isExpired && (!options?.validate || options.validate(data))) {
-      return data;
+  const wrappedFn = async (...args: Parameters<Fn>) => {
+    const key =
+      hash(args || []) + (options as unknown as { internal_cacheKeySuffix?: string })?.internal_cacheKeySuffix;
+    const cached = cache.get(key);
+    if (cached) {
+      const { data, timestamp } = JSON.parse(cached, reviver);
+      const isExpired = options?.maxAge && Date.now() - timestamp > options.maxAge;
+      if (!isExpired && (!options?.validate || options.validate(data))) {
+        return data;
+      }
     }
-  }
 
-  const result = await fn();
-  cache.set(
-    key,
-    JSON.stringify(
-      {
-        data: result,
-        timestamp: Date.now(),
-      },
-      replacer,
-    ),
-  );
-  return result;
+    const result = await fn();
+    cache.set(
+      key,
+      JSON.stringify(
+        {
+          data: result,
+          timestamp: Date.now(),
+        },
+        replacer,
+      ),
+    );
+    return result;
+  };
+
+  wrappedFn.clearCache = () => {
+    cache.clear();
+  };
+
+  // @ts-expect-error too complex for TS
+  return wrappedFn;
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,49 @@
+import { Cache } from "@raycast/api";
+import { hash } from "./helpers";
+
+/**
+ * Wraps a function with caching functionality using Raycast's Cache API.
+ * Allows for caching of expensive functions like paginated API calls.
+ *
+ * @param fn - The async function to cache results from
+ * @param options - Optional configuration for the cache behavior
+ * @param options.key - Custom cache key (defaults to stringified function)
+ * @param options.validate - Optional validation function for cached data
+ * @param options.maxAge - Maximum age of cached data in milliseconds
+ * @param options.namespace - Optional namespace for the cache
+ * @returns The result of the function, either from cache or fresh execution
+ *
+ * @example
+ * ```ts
+ * const data = await withCache(
+ *   async () => fetchExpensiveData(),
+ *   { maxAge: 5 * 60 * 1000 } // Cache for 5 minutes
+ * );
+ * ```
+ */
+export async function withCache<T>(
+  fn: () => Promise<T>,
+  options?: { key?: string; validate?: (data: T) => boolean; maxAge?: number; namespace?: string },
+): Promise<T> {
+  const cache = new Cache({ namespace: options?.namespace });
+
+  const key = options?.key ?? hash(fn);
+  const cached = cache.get(key);
+  if (cached) {
+    const { data, timestamp } = JSON.parse(cached);
+    const isExpired = options?.maxAge && Date.now() - timestamp > options.maxAge;
+    if (!isExpired && (!options?.validate || options.validate(data))) {
+      return data;
+    }
+  }
+
+  const result = await fn();
+  cache.set(
+    key,
+    JSON.stringify({
+      data: result,
+      timestamp: Date.now(),
+    }),
+  );
+  return result;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export * from "./createDeeplink";
 export * from "./executeSQL";
 export * from "./run-applescript";
 export * from "./showFailureToast";
+export * from "./cache";
 
 export type { AsyncState, MutatePromise } from "./types";
 export type { Response } from "cross-fetch";

--- a/src/useCachedPromise.ts
+++ b/src/useCachedPromise.ts
@@ -149,7 +149,7 @@ export function useCachedPromise<
   const lastUpdateFrom = useRef<"cache" | "promise">();
 
   const [cachedData, mutateCache] = useCachedState<typeof emptyCache | (UnwrapReturn<T> | U)>(
-    hash(args || []) + internal_cacheKeySuffix ?? "",
+    hash(args || []) + internal_cacheKeySuffix,
     emptyCache,
     {
       cacheNamespace: hash(fn),

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -21,7 +21,7 @@
     },
     "..": {
       "name": "@raycast/utils",
-      "version": "1.16.4",
+      "version": "1.18.1",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.1.6",
@@ -32,7 +32,7 @@
         "stream-json": "^1.8.0"
       },
       "devDependencies": {
-        "@raycast/api": "1.79.1",
+        "@raycast/api": "1.52.0",
         "@types/content-type": "^1.1.6",
         "@types/object-hash": "^3.0.4",
         "@types/signal-exit": "^3.0.2",
@@ -4010,7 +4010,7 @@
     "@raycast/utils": {
       "version": "file:..",
       "requires": {
-        "@raycast/api": "1.79.1",
+        "@raycast/api": "1.52.0",
         "@types/content-type": "^1.1.6",
         "@types/object-hash": "^3.0.4",
         "@types/signal-exit": "^3.0.2",

--- a/tests/package.json
+++ b/tests/package.json
@@ -220,6 +220,13 @@
           "type": "text"
         }
       ]
+    },
+    {
+      "name": "cache",
+      "title": "withCache",
+      "subtitle": "Utils Smoke Tests",
+      "description": "Utils Smoke Tests",
+      "mode": "no-view"
     }
   ],
   "dependencies": {

--- a/tests/src/cache.ts
+++ b/tests/src/cache.ts
@@ -1,0 +1,21 @@
+import { showToast } from "@raycast/api";
+import { withCache } from "@raycast/utils";
+
+async function expensiveFunction() {
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  return "Hello, world!";
+}
+
+export default async function () {
+  console.time("Uncached");
+  const res = await withCache(expensiveFunction);
+  console.timeEnd("Uncached");
+
+  await showToast({ title: "Uncached result: " + res });
+
+  console.time("Cached");
+  const res2 = await withCache(expensiveFunction);
+  console.timeEnd("Cached");
+
+  await showToast({ title: "Cached result: " + res2 });
+}

--- a/tests/src/cache.ts
+++ b/tests/src/cache.ts
@@ -6,15 +6,17 @@ async function expensiveFunction() {
   return "Hello, world!";
 }
 
+const cachedFrunction = withCache(expensiveFunction);
+
 export default async function () {
   console.time("Uncached");
-  const res = await withCache(expensiveFunction);
+  const res = await cachedFrunction();
   console.timeEnd("Uncached");
 
   await showToast({ title: "Uncached result: " + res });
 
   console.time("Cached");
-  const res2 = await withCache(expensiveFunction);
+  const res2 = await cachedFrunction();
   console.timeEnd("Cached");
 
   await showToast({ title: "Cached result: " + res2 });


### PR DESCRIPTION
Adding a new utility function that helps wrapping expensive functions like long-running API calls insie a cache function. Few gimmicks:
1. Have some TTL that invalidates the cache
2. Hash the function to easily use the cache without specifying a key
3. Add some validate function to allow invalidating the cache. This is handy when you want to search a list first with cached results but then do some network call in case something wasn't found in the cached results.