### PR TITLE
Fix types for ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,14 @@
   "types": "dist/types.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/module.js",
-      "require": "./dist/main.js"
+      "import": {
+        "default": "./dist/module.js",
+        "types": "./dist/types.d.ts"
+      },
+      "require": {
+        "default": "./dist/main.js",
+        "types": "./dist/types.d.ts"
+      }
     }
   },
   "scripts": {


### PR DESCRIPTION
I got a missing declaration error while importing `@raycast/utils@2` in my ESM extension.

The `types` should be defined in the `exports` entries.