### PR TITLE
Polish export entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,9 @@
   "types": "dist/types.d.ts",
   "exports": {
     ".": {
-      "import": {
-        "default": "./dist/module.js",
-        "types": "./dist/types.d.ts"
-      },
-      "require": {
-        "default": "./dist/main.js",
-        "types": "./dist/types.d.ts"
-      }
+      "types": "./dist/types.d.ts",
+      "import": "./dist/module.js",
+      "require": "./dist/main.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
The `types` can be written at the same level as import/require.

I also moved the `types` field to the top as Node.js recommended (https://nodejs.org/api/packages.html#community-conditions-definitions).