### PR TITLE
fix: broken relative URL for gitbook assets for markdown

### DIFF
--- a/docs/utils-reference/getting-started.md
+++ b/docs/utils-reference/getting-started.md
@@ -2,7 +2,7 @@
 
 In addition to the [Raycast API](../api-reference/cache.md) which is bundled as part of the app, we also provide a sibling package that contains a set of utilities to streamline common patterns and operations used in extensions.
 
-![](../.gitbook/assets/utils-illustration.jpg)
+![](.gitbook/assets/utils-illustration.jpg)
 
 ## Installation
 

--- a/docs/utils-reference/icons/getAvatarIcon.md
+++ b/docs/utils-reference/icons/getAvatarIcon.md
@@ -2,7 +2,7 @@
 
 Icon to represent an avatar when you don't have one. The generated avatar will be generated from the initials of the name and have a colorful but consistent background.
 
-![Avatar Icon example](../../.gitbook/assets/utils-avatar-icon.png)
+![Avatar Icon example](../.gitbook/assets/utils-avatar-icon.png)
 
 ## Signature
 

--- a/docs/utils-reference/icons/getFavicon.md
+++ b/docs/utils-reference/icons/getFavicon.md
@@ -4,7 +4,7 @@ Icon showing the favicon of a website.
 
 A favicon (favorite icon) is a tiny icon included along with a website, which is displayed in places like the browser's address bar, page tabs, and bookmarks menu.
 
-![Favicon example](../../.gitbook/assets/utils-favicon.png)
+![Favicon example](../.gitbook/assets/utils-favicon.png)
 
 ## Signature
 

--- a/docs/utils-reference/icons/getProgressIcon.md
+++ b/docs/utils-reference/icons/getProgressIcon.md
@@ -2,7 +2,7 @@
 
 Icon to represent the progress of a task, a project, _something_.
 
-![Progress Icon example](../../.gitbook/assets/utils-progress-icon.png)
+![Progress Icon example](../.gitbook/assets/utils-progress-icon.png)
 
 ## Signature
 


### PR DESCRIPTION
## Description
This PR updates image paths in the documentation to ensure consistency and correct referencing of asset files.

## Changes
- **docs/utils-reference/getting-started.md**
  - Fixed relative path for the utils illustration image.
- **docs/utils-reference/icons/getAvatarIcon.md**
  - Corrected avatar icon example path.
- **docs/utils-reference/icons/getFavicon.md**
  - Updated favicon example image path to correct assets directory.
- **docs/utils-reference/icons/getProgressIcon.md**
  - Fixed progress icon example image path.

## Screenshots

| Before | After |
|:------:|:-----:|
| <img width="1122" height="492" alt="image" src="https://github.com/user-attachments/assets/526855f2-d9a7-4e77-8340-ae7ef9bb8ec7" />  | <img width="1172" height="818" alt="Click-2025-10-03-09 54 16" src="https://github.com/user-attachments/assets/c263891f-d3fc-4c88-9702-f79fb82d275c" />  |
| <img width="1063" height="164" alt="image" src="https://github.com/user-attachments/assets/a5f86328-1211-4f41-8039-0821939b06b7" />  | <img width="1088" height="257" alt="Click-2025-10-03-09 54 00" src="https://github.com/user-attachments/assets/35aad4a5-6b2f-4fc7-bd6d-30a424b764b3" />  |

## Testing Steps
1. Open each updated Markdown file in GitHub/Docs preview.
2. Verify that all images load correctly.
3. Confirm no broken links remain.

## Checklist
- [x] All updated images render properly in docs preview.
- [x] No broken or duplicate asset paths.
- [x] Consistency across all utils-reference documentation.