### PR TITLE
fix: no error when db not exist in useSQL

### DIFF
--- a/src/useSQL.tsx
+++ b/src/useSQL.tsx
@@ -81,10 +81,6 @@ export function useSQL<T = unknown>(
   );
 
   const fn = useMemo(() => {
-    if (!existsSync(databasePath)) {
-      throw new Error("The database does not exist");
-    }
-
     return async (databasePath: string, query: string) => {
       const abortSignal = abortable.current?.signal;
       return baseExecuteSQL<T>(databasePath, query, { signal: abortSignal });


### PR DESCRIPTION
Currently, `⁠useSQL` performs an `⁠existsSync` check synchronously inside ⁠`useMemo`. If the file is missing, this throws an error during the React render phase, causing the entire component to crash (noticed this because of https://github.com/raycast/extensions/pull/23965) which means no `onError` 🥲.

Since `⁠baseExecuteSQL` already checks for file existence, we can safely remove the lines and cause the error to be handled.

There is no test case in the `tests` folder but if needed, I can create one.
