### PR TITLE
Add cross-OS exec support to useExec and a new imperative exec

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,11 @@ on:
 jobs:
   tests:
     if: github.repository == 'raycast/utils'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: raycast/github-actions/git-checkout@v1.13.0
@@ -30,9 +34,15 @@ jobs:
         run: npm run test
       - name: Build
         run: npm run build
+      - name: Unit Tests
+        run: npm run test:unit
+      # The Raycast CLI's `ray build` does not run on Windows, so Windows coverage
+      # stops at the unit tests above; the example extension builds on Linux and macOS.
       - name: Npm Install Tests
+        if: runner.os != 'Windows'
         run: npm ci
         working-directory: ./tests
       - name: Build tests
+        if: runner.os != 'Windows'
         run: npm run build
         working-directory: ./tests

--- a/docs/utils-reference/SUMMARY.md
+++ b/docs/utils-reference/SUMMARY.md
@@ -3,6 +3,7 @@
 - [Getting Started](utils-reference/getting-started.md)
 - [Functions](utils-reference/functions/README.md)
   - [createDeeplink](utils-reference/functions/createDeeplink.md)
+  - [exec](utils-reference/functions/exec.md)
   - [executeSQL](utils-reference/functions/executeSQL.md)
   - [runAppleScript](utils-reference/functions/runAppleScript.md)
   - [runPowerShellScript](utils-reference/functions/runPowerShellScript.md)

--- a/docs/utils-reference/functions/exec.md
+++ b/docs/utils-reference/functions/exec.md
@@ -1,0 +1,96 @@
+# `exec`
+
+A function that executes a command and returns a `Promise` that resolves with its parsed output.
+
+This is the imperative sibling of [`useExec`](../react-hooks/useExec.md), meant for code that runs outside of a React render: AI tool functions, `no-view` commands, and scripts. It shares the same cross-OS command resolution as the hook, so the same call works on macOS, Linux, and Windows. On Windows it resolves `.cmd`/`.bat` shims through `PATHEXT` (so `npx` finds `npx.cmd` instead of throwing `ENOENT`) and escapes arguments correctly, without needing the `shell` option.
+
+## Signature
+
+There are two ways to use the function.
+
+The first one should be preferred when executing a single file. The file and its arguments don't have to be escaped.
+
+```ts
+function exec<T = string>(
+  file: string,
+  arguments: string[],
+  options?: {
+    shell?: boolean | string;
+    stripFinalNewline?: boolean;
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+    encoding?: BufferEncoding | "buffer";
+    input?: string | Buffer;
+    timeout?: number;
+    signal?: AbortSignal;
+    parseOutput?: ParseExecOutputHandler<T>;
+  },
+): Promise<T>;
+```
+
+The second one can be used to execute more complex commands. The file and arguments are specified in a single `command` string. For example, `exec("echo", ["Raycast"])` is the same as `exec("echo Raycast")`.
+
+If the file or an argument contains spaces, they must be escaped with backslashes. This matters especially if `command` is not a constant but a variable, for example with `environment.supportPath` or `process.cwd()`. Except for spaces, no escaping/quoting is needed.
+
+The `shell` option must be used if the command uses shell-specific features (for example, `&&` or `||`), as opposed to being a simple file followed by its arguments.
+
+```ts
+function exec<T = string>(
+  command: string,
+  options?: {
+    shell?: boolean | string;
+    stripFinalNewline?: boolean;
+    cwd?: string;
+    env?: NodeJS.ProcessEnv;
+    encoding?: BufferEncoding | "buffer";
+    input?: string | Buffer;
+    timeout?: number;
+    signal?: AbortSignal;
+    parseOutput?: ParseExecOutputHandler<T>;
+  },
+): Promise<T>;
+```
+
+### Arguments
+
+- `file` is the path to the file to execute.
+- `arguments` is an array of strings to pass as arguments to the file.
+
+or
+
+- `command` is the string to execute.
+
+With a few options:
+
+- `options.shell` is a boolean or a string to tell whether to run the command inside of a shell or not. If `true`, uses `/bin/sh`. A different shell can be specified as a string. The shell should understand the `-c` switch.
+
+  We recommend against using this option since it is:
+
+  - not cross-platform, encouraging shell-specific syntax.
+  - slower, because of the additional shell interpretation.
+  - unsafe, potentially allowing command injection.
+
+- `options.stripFinalNewline` is a boolean to tell the function to strip the final newline character from the output. By default, it will.
+- `options.cwd` is a string to specify the current working directory of the child process. By default, it will be `process.cwd()`.
+- `options.env` is a key-value pairs to set as the environment of the child process. It will extend automatically from `process.env`.
+- `options.encoding` is a string to specify the character encoding used to decode the `stdout` and `stderr` output. If set to `"buffer"`, then `stdout` and `stderr` will be a `Buffer` instead of a string.
+- `options.input` is a string or a Buffer to write to the `stdin` of the file.
+- `options.timeout` is a number. If greater than `0`, the parent will send the signal `SIGTERM` if the child runs longer than timeout milliseconds. By default, the execution will timeout after 10000ms (eg. 10s).
+- `options.signal` is an `AbortSignal` that allows you to abort the command via an `AbortController`.
+- `options.parseOutput` is a function that accepts the output of the child process as an argument and returns the data the function will resolve with - see [ParseExecOutputHandler](../react-hooks/useExec.md#parseexecoutputhandler). By default, the function will return `stdout`.
+
+### Return
+
+Returns a `Promise` that resolves with the parsed output of the command (by default, its `stdout` as a string). If the command fails, times out, or is killed by a signal, the `Promise` rejects with an `Error` carrying `exitCode`, `signal`, `stdout`, and `stderr`.
+
+## Example
+
+```typescript
+import { Clipboard } from "@raycast/api";
+import { exec } from "@raycast/utils";
+
+export default async function Command() {
+  const output = await exec("git", ["rev-parse", "HEAD"], { cwd: "/path/to/repo" });
+  await Clipboard.copy(output);
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.2.5",
       "license": "MIT",
       "dependencies": {
+        "cross-spawn": "^7.0.6",
         "dequal": "^2.0.3"
       },
       "devDependencies": {
@@ -16,10 +17,13 @@
         "@parcel/transformer-typescript-types": "^2.16.4",
         "@raycast/api": "1.99.4",
         "@raycast/eslint-config": "^2.0.4",
+        "@types/cross-spawn": "^6.0.6",
         "@types/node": "22.13.4",
         "eslint": "^9.22.0",
         "parcel": "^2.16.4",
         "prettier": "^3.5.3",
+        "rimraf": "^6.1.3",
+        "tsx": "^4.22.4",
         "typescript": "^5.8.2"
       },
       "peerDependencies": {
@@ -1507,7 +1511,6 @@
       "integrity": "sha512-a0CgrW5A5kwuSu5J1RFRoMQaMs9yagvfH2jJMYVw56+/7NRI4KOtu612SG9Y1ERWfY55ZwzyFxtLWvD6LO+Anw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.1",
         "@parcel/cache": "2.16.4",
@@ -3499,6 +3502,16 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@types/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -3519,7 +3532,6 @@
       "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -3910,7 +3922,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4071,7 +4082,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4254,7 +4264,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4449,7 +4458,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4772,6 +4780,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -4792,6 +4815,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -4803,6 +4844,45 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -4974,7 +5054,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jake": {
@@ -5406,6 +5485,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -5420,6 +5509,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -5616,6 +5715,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parcel": {
       "version": "2.16.4",
       "resolved": "https://registry.npmjs.org/parcel/-/parcel-2.16.4.tgz",
@@ -5677,10 +5783,26 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/picocolors": {
@@ -5713,7 +5835,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5771,6 +5892,26 @@
         "node": ">=4"
       }
     },
+    "node_modules/rimraf": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
+      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "glob": "^13.0.3",
+        "package-json-from-dist": "^1.0.1"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -5816,7 +5957,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5829,7 +5969,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5959,7 +6098,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5973,6 +6111,509 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6006,7 +6647,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6074,7 +6714,6 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -6316,7 +6955,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
   },
   "scripts": {
     "lint": "eslint src/",
-    "build": "(rm -rf .parcel-cache || true) && (rm -rf dist || true) && parcel build",
+    "build": "rimraf .parcel-cache dist && parcel build",
     "dev": "parcel watch",
     "test": "npm run lint",
+    "test:unit": "tsx --test \"src/**/*.test.ts\"",
     "prepublishOnly": "npm run build && npm test",
     "postpublish": "gh workflow run sync-utils-docs.yml --repo raycast/extensions"
   },
@@ -43,17 +44,21 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "cross-spawn": "^7.0.6",
     "dequal": "^2.0.3"
   },
   "devDependencies": {
-    "@raycast/eslint-config": "^2.0.4",
     "@parcel/packager-ts": "^2.16.4",
     "@parcel/transformer-typescript-types": "^2.16.4",
     "@raycast/api": "1.99.4",
+    "@raycast/eslint-config": "^2.0.4",
+    "@types/cross-spawn": "^6.0.6",
     "@types/node": "22.13.4",
     "eslint": "^9.22.0",
+    "parcel": "^2.16.4",
     "prettier": "^3.5.3",
-    "typescript": "^5.8.2",
-    "parcel": "^2.16.4"
+    "rimraf": "^6.1.3",
+    "tsx": "^4.22.4",
+    "typescript": "^5.8.2"
   }
 }

--- a/src/exec-utils.ts
+++ b/src/exec-utils.ts
@@ -2,7 +2,52 @@ import childProcess from "node:child_process";
 import { constants as BufferConstants } from "node:buffer";
 import Stream from "node:stream";
 import { promisify } from "node:util";
+import crossSpawn from "cross-spawn";
 import { onExit } from "./vendors/signal-exit";
+
+export type ExecOptions = {
+  /**
+   * If `true`, runs the command inside of a shell. Uses `/bin/sh`. A different shell can be specified as a string. The shell should understand the `-c` switch.
+   *
+   * We recommend against using this option since it is:
+   * - not cross-platform, encouraging shell-specific syntax.
+   * - slower, because of the additional shell interpretation.
+   * - unsafe, potentially allowing command injection.
+   *
+   * @default false
+   */
+  shell?: boolean | string;
+  /**
+   * Strip the final newline character from the output.
+   * @default true
+   */
+  stripFinalNewline?: boolean;
+  /**
+   * Current working directory of the child process.
+   * @default process.cwd()
+   */
+  cwd?: string;
+  /**
+   * Environment key-value pairs. Extends automatically from `process.env`.
+   * @default process.env
+   */
+  env?: NodeJS.ProcessEnv;
+  /**
+   * Specify the character encoding used to decode the stdout and stderr output. If set to `"buffer"`, then stdout and stderr will be a Buffer instead of a string.
+   *
+   * @default "utf8"
+   */
+  encoding?: BufferEncoding | "buffer";
+  /**
+   * Write some input to the `stdin` of your binary.
+   */
+  input?: string | Buffer;
+  /** If timeout is greater than `0`, the parent will send the signal `SIGTERM` if the child runs longer than timeout milliseconds.
+   *
+   * @default 10000
+   */
+  timeout?: number;
+};
 
 export type SpawnedPromise = Promise<{
   exitCode: number | null;
@@ -331,4 +376,93 @@ export function defaultParsing<T extends string | Buffer>({
   }
 
   return stdout;
+}
+
+const SPACES_REGEXP = / +/g;
+export function parseCommand(command: string, args?: string[]) {
+  if (args) {
+    return [command, ...args];
+  }
+  const tokens: string[] = [];
+  for (const token of command.trim().split(SPACES_REGEXP)) {
+    // Allow spaces to be escaped by a backslash if not meant as a delimiter
+    const previousToken = tokens[tokens.length - 1];
+    if (previousToken && previousToken.endsWith("\\")) {
+      // Merge previous token with current one
+      tokens[tokens.length - 1] = `${previousToken.slice(0, -1)} ${token}`;
+    } else {
+      tokens.push(token);
+    }
+  }
+
+  return tokens;
+}
+
+/**
+ * Cross-OS-correct command execution shared by `useExec` and the imperative `exec`.
+ *
+ * Uses `cross-spawn` in place of `childProcess.spawn` so commands resolve across `PATH` + `PATHEXT`
+ * (finding `.cmd`/`.bat` shims like `npx.cmd`), read `PATH` under its real case-insensitive key, and
+ * are escaped correctly when Windows routes them through `cmd.exe`, without the injection hazards of
+ * `shell: true`. On macOS/Linux `cross-spawn` delegates straight to `childProcess.spawn`, so behavior
+ * there is unchanged.
+ */
+export async function baseExec<T = string>(
+  _command: string,
+  _args?: string[],
+  _options?: ExecOptions & {
+    parseOutput?: ParseExecOutputHandler<T, string | Buffer, ExecOptions>;
+    /**
+     * A Signal object that allows you to abort the command if required via an AbortController object.
+     */
+    signal?: AbortSignal;
+  },
+): Promise<T> {
+  const { parseOutput, input, signal, ...execOptions } = _options ?? {};
+  const [file, ...args] = parseCommand(_command, _args);
+  const command = [file, ...args].join(" ");
+
+  const options = {
+    stripFinalNewline: true,
+    ...execOptions,
+    timeout: execOptions.timeout || 10000,
+    signal,
+    encoding: execOptions.encoding || "utf8",
+    env: {
+      // The default Unix `PATH` is meaningless on Windows and would collide with `process.env.Path`.
+      ...(process.platform === "win32" ? {} : { PATH: "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" }),
+      ...process.env,
+      ...execOptions.env,
+    },
+  };
+
+  const spawned = crossSpawn(file, args, options) as childProcess.ChildProcessWithoutNullStreams;
+  const spawnedPromise = getSpawnedPromise(spawned, options);
+
+  if (input) {
+    spawned.stdin.end(input);
+  }
+
+  const [{ error, exitCode, signal: exitSignal, timedOut }, stdoutResult, stderrResult] = await getSpawnedResult(
+    spawned,
+    options,
+    spawnedPromise,
+  );
+  const stdout = handleOutput(options, stdoutResult);
+  const stderr = handleOutput(options, stderrResult);
+
+  const parse = parseOutput ?? (defaultParsing as ParseExecOutputHandler<T, string | Buffer, ExecOptions>);
+  const parseArgs = {
+    stdout,
+    stderr,
+    error,
+    exitCode,
+    signal: exitSignal,
+    timedOut,
+    command,
+    options,
+    parentError: new Error(),
+  };
+
+  return parse(parseArgs) as T;
 }

--- a/src/exec.test.ts
+++ b/src/exec.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { exec } from "./exec";
+
+// `npm` is a `.cmd` shim on Windows and a real binary elsewhere. Resolving it proves cross-spawn's
+// PATHEXT lookup works: pre-fix, `spawn("npm", …)` throws ENOENT on Windows runners.
+test("exec resolves a .cmd shim on Windows (npm)", async () => {
+  const output = await exec("npm", ["--version"]);
+  assert.match(output, /^\d+\.\d+\.\d+/);
+});
+
+test("exec runs a real binary (node)", async () => {
+  const output = await exec("node", ["--version"]);
+  assert.match(output, /^v\d+\.\d+\.\d+/);
+});
+
+test("exec parses a command string into file and args", async () => {
+  const output = await exec("node --version");
+  assert.match(output, /^v\d+\.\d+\.\d+/);
+});
+
+test("exec returns a Buffer when encoding is 'buffer'", async () => {
+  const output = await exec("node", ["--version"], { encoding: "buffer" });
+  assert.ok(Buffer.isBuffer(output));
+});
+
+test("exec throws on a non-zero exit code", async () => {
+  await assert.rejects(() => exec("node", ["-e", "process.exit(1)"]));
+});

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -1,0 +1,84 @@
+import { baseExec, ExecOptions, ParseExecOutputHandler } from "./exec-utils";
+
+/**
+ * Executes a command and returns a Promise that resolves with its parsed output. This is the
+ * imperative sibling of {@link useExec}, for use outside of React render (AI tools, `no-view`
+ * commands, scripts).
+ *
+ * Like `useExec`, it resolves the command across the OS so the same call works on macOS, Linux, and
+ * Windows: on Windows it finds `.cmd`/`.bat` shims via `PATHEXT` (so `npx` resolves to `npx.cmd`
+ * instead of throwing `ENOENT`) and escapes arguments correctly, without needing `shell: true`.
+ *
+ * @remark When specifying the arguments via the `command` string, if the file or an argument of the command contains spaces, they must be escaped with backslashes. This matters especially if `command` is not a constant but a variable, for example with `__dirname` or `process.cwd()`. Except for spaces, no escaping/quoting is needed.
+ *
+ * The `shell` option must be used if the command uses shell-specific features (for example, `&&` or `||`), as opposed to being a simple file followed by its arguments.
+ *
+ * @example
+ * ```typescript
+ * import { exec } from "@raycast/utils";
+ *
+ * export default async function () {
+ *   const output = await exec("brew", ["info", "--json=v2", "--installed"]);
+ *   const formulae = JSON.parse(output).formulae;
+ *   // ...
+ * }
+ * ```
+ */
+type ExecImperativeOptions = ExecOptions & {
+  /**
+   * A Signal object that allows you to abort the command if required via an AbortController object.
+   */
+  signal?: AbortSignal;
+};
+
+export async function exec<T = string>(
+  command: string,
+  options?: {
+    parseOutput?: ParseExecOutputHandler<T, string, ExecOptions>;
+  } & ExecImperativeOptions & { encoding?: BufferEncoding },
+): Promise<T>;
+export async function exec<T = Buffer>(
+  command: string,
+  options: {
+    parseOutput?: ParseExecOutputHandler<T, Buffer, ExecOptions>;
+  } & ExecImperativeOptions & { encoding: "buffer" },
+): Promise<T>;
+export async function exec<T = string>(
+  file: string,
+  /**
+   * The arguments to pass to the file. No escaping/quoting is needed.
+   */
+  args: string[],
+  options?: {
+    parseOutput?: ParseExecOutputHandler<T, string, ExecOptions>;
+  } & ExecImperativeOptions & { encoding?: BufferEncoding },
+): Promise<T>;
+export async function exec<T = Buffer>(
+  file: string,
+  /**
+   * The arguments to pass to the file. No escaping/quoting is needed.
+   */
+  args: string[],
+  options: {
+    parseOutput?: ParseExecOutputHandler<T, Buffer, ExecOptions>;
+  } & ExecImperativeOptions & { encoding: "buffer" },
+): Promise<T>;
+export async function exec<T = string>(
+  command: string,
+  optionsOrArgs?:
+    | string[]
+    | ({
+        parseOutput?: ParseExecOutputHandler<T, Buffer, ExecOptions> | ParseExecOutputHandler<T, string, ExecOptions>;
+      } & ExecImperativeOptions),
+  options?: {
+    parseOutput?: ParseExecOutputHandler<T, Buffer, ExecOptions> | ParseExecOutputHandler<T, string, ExecOptions>;
+  } & ExecImperativeOptions,
+): Promise<T> {
+  const args = Array.isArray(optionsOrArgs) ? optionsOrArgs : undefined;
+  const execOptions = (Array.isArray(optionsOrArgs) ? options : optionsOrArgs) ?? {};
+
+  return baseExec<T>(command, args, {
+    ...execOptions,
+    parseOutput: execOptions.parseOutput as ParseExecOutputHandler<T, string | Buffer, ExecOptions>,
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export { OAuthService, withAccessToken, getAccessToken } from "./oauth";
 
 export { createDeeplink, createExtensionDeeplink, createScriptCommandDeeplink, DeeplinkType } from "./createDeeplink";
 export { executeSQL } from "./executeSQL";
+export { exec } from "./exec";
 export { runAppleScript } from "./run-applescript";
 export { runPowerShellScript } from "./run-powershell-script";
 export { showFailureToast } from "./showFailureToast";

--- a/src/useExec.ts
+++ b/src/useExec.ts
@@ -2,83 +2,12 @@
  * Inspired by Execa
  */
 
-import childProcess from "node:child_process";
 import { useCallback, useRef } from "react";
 
 import { useCachedPromise, CachedPromiseOptions } from "./useCachedPromise";
 import { useLatest } from "./useLatest";
 import { UseCachedPromiseReturnType } from "./types";
-import {
-  getSpawnedPromise,
-  getSpawnedResult,
-  handleOutput,
-  defaultParsing,
-  ParseExecOutputHandler,
-} from "./exec-utils";
-
-type ExecOptions = {
-  /**
-   * If `true`, runs the command inside of a shell. Uses `/bin/sh`. A different shell can be specified as a string. The shell should understand the `-c` switch.
-   *
-   * We recommend against using this option since it is:
-   * - not cross-platform, encouraging shell-specific syntax.
-   * - slower, because of the additional shell interpretation.
-   * - unsafe, potentially allowing command injection.
-   *
-   * @default false
-   */
-  shell?: boolean | string;
-  /**
-   * Strip the final newline character from the output.
-   * @default true
-   */
-  stripFinalNewline?: boolean;
-  /**
-   * Current working directory of the child process.
-   * @default process.cwd()
-   */
-  cwd?: string;
-  /**
-   * Environment key-value pairs. Extends automatically from `process.env`.
-   * @default process.env
-   */
-  env?: NodeJS.ProcessEnv;
-  /**
-   * Specify the character encoding used to decode the stdout and stderr output. If set to `"buffer"`, then stdout and stderr will be a Buffer instead of a string.
-   *
-   * @default "utf8"
-   */
-  encoding?: BufferEncoding | "buffer";
-  /**
-   * Write some input to the `stdin` of your binary.
-   */
-  input?: string | Buffer;
-  /** If timeout is greater than `0`, the parent will send the signal `SIGTERM` if the child runs longer than timeout milliseconds.
-   *
-   * @default 10000
-   */
-  timeout?: number;
-};
-
-const SPACES_REGEXP = / +/g;
-function parseCommand(command: string, args?: string[]) {
-  if (args) {
-    return [command, ...args];
-  }
-  const tokens: string[] = [];
-  for (const token of command.trim().split(SPACES_REGEXP)) {
-    // Allow spaces to be escaped by a backslash if not meant as a delimiter
-    const previousToken = tokens[tokens.length - 1];
-    if (previousToken && previousToken.endsWith("\\")) {
-      // Merge previous token with current one
-      tokens[tokens.length - 1] = `${previousToken.slice(0, -1)} ${token}`;
-    } else {
-      tokens.push(token);
-    }
-  }
-
-  return tokens;
-}
+import { baseExec, defaultParsing, ExecOptions, ParseExecOutputHandler } from "./exec-utils";
 
 type ExecCachedPromiseOptions<T, U> = Omit<
   CachedPromiseOptions<
@@ -198,46 +127,12 @@ export function useExec<T, U = undefined>(
 
   const fn = useCallback(
     async (_command: string, _args: string[], _options?: ExecOptions, input?: string | Buffer) => {
-      const [file, ...args] = parseCommand(_command, _args);
-      const command = [file, ...args].join(" ");
-
-      const options = {
-        stripFinalNewline: true,
+      return baseExec<T>(_command, _args, {
         ..._options,
-        timeout: _options?.timeout || 10000,
-        signal: abortable.current?.signal,
-        encoding: _options?.encoding === null ? "buffer" : _options?.encoding || "utf8",
-        env: { PATH: "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin", ...process.env, ..._options?.env },
-      };
-
-      const spawned = childProcess.spawn(file, args, options);
-      const spawnedPromise = getSpawnedPromise(spawned, options);
-
-      if (input) {
-        spawned.stdin.end(input);
-      }
-
-      const [{ error, exitCode, signal, timedOut }, stdoutResult, stderrResult] = await getSpawnedResult(
-        spawned,
-        options,
-        spawnedPromise,
-      );
-      const stdout = handleOutput(options, stdoutResult);
-      const stderr = handleOutput(options, stderrResult);
-
-      return parseOutputRef.current({
-        // @ts-expect-error too many generics, I give up
-        stdout,
-        // @ts-expect-error too many generics, I give up
-        stderr,
-        error,
-        exitCode,
-        signal,
-        timedOut,
-        command,
-        options,
-        parentError: new Error(),
-      }) as T;
+        input,
+        signal: abortable.current?.signal ?? undefined,
+        parseOutput: parseOutputRef.current as ParseExecOutputHandler<T, string | Buffer, ExecOptions>,
+      });
     },
     [parseOutputRef],
   );


### PR DESCRIPTION
Swaps `childProcess.spawn` for [`cross-spawn`](https://www.npmjs.com/package/cross-spawn) in a shared `baseExec` core and exposes a new imperative `exec`, so command resolution works the same on macOS, Linux, and Windows.

The motivation is [raycast/extensions#28449](https://github.com/raycast/extensions/pull/28449), which adds Windows support to ccusage. Almost all of that diff is one pattern repeated: the extension's views call `useExec`, while its AI tools call raw `child_process.exec`. The raw-exec path has to hand-build, per command, what a cross-OS `useExec` would give for free: resolving `.cmd`/`.bat` shims via `PATHEXT` (so `npx` finds `npx.cmd` instead of `ENOENT`), reading `PATH` under its real case-correct key (`Path` vs `PATH`), and escaping Windows arguments without `shell: true`.

Two things made this worth fixing in the library. First, `useExec` did not actually do cross-OS resolution: despite the "Inspired by Execa" comment it called `childProcess.spawn` directly and hardcoded a Unix `PATH`, so it only happened to work on macOS. Second, there was no imperative `exec` sibling, which is exactly why non-React code drops to raw `child_process`.

## Changes

- Extracts the body of `useExec`'s callback into `baseExec` in `exec-utils.ts` (mirroring `baseExecuteSQL` in `sql-utils.ts`), reusing the existing `getSpawnedPromise`/`getSpawnedResult`/`handleOutput`/`defaultParsing` helpers.
- `baseExec` calls `cross-spawn` instead of `childProcess.spawn`. cross-spawn resolves the command across `PATH` + `PATHEXT`, reads `PATH` case-insensitively, and escapes args itself when a target needs `cmd.exe`. On macOS/Linux it delegates straight to `child_process.spawn`, so existing behavior is unchanged.
- Gates the hardcoded Unix `PATH` default to non-Windows, so it neither injects a bogus `/usr/...` value nor collides with `process.env.Path`. The default stays lowest-priority, overridden by `process.env` then the caller's `env`.
- `useExec`'s callback becomes a thin wrapper over `baseExec`. No behavior change for existing callers.
- Adds `exec(command, args?, options?)` in `exec.ts`, with overloads mirroring `useExec` (command-string vs file+args, `encoding: "buffer"` vs string, `parseOutput`) minus the React/caching options. I kept it `@raycast/api`-free so it is importable and testable outside a React render. This is the sibling AI tools and `no-view` commands can call instead of raw `child_process`.
- I scoped the new `signal` option to `baseExec` and the public `exec` rather than the shared `ExecOptions`, so `useExec`'s surface is unchanged (the hook manages its own `AbortController`).
- Adds `cross-spawn` to `dependencies` and `@types/cross-spawn` to `devDependencies` (cross-spawn ships no types).

## Testing

The exec fix is cross-platform behavior, so CI now runs on Windows and macOS, not just Ubuntu:

- Matrices the Test workflow over `ubuntu-latest`, `windows-latest`, and `macos-latest`.
- Replaces the `rm -rf` build script with `rimraf` so `npm run build` works under `cmd.exe` on Windows.
- Adds a React-free `node:test` unit suite (run via `tsx`) that resolves `npm` (a `.cmd` shim on Windows) and `node`. The `exec("npm", ["--version"])` case passing on `windows-latest` is the direct proof that `.cmd`/`PATHEXT` resolution works; it would `ENOENT` before this change. This is the payoff of the imperative export: the core is unit-testable without a React renderer.
- The Raycast CLI's `ray build` does not run on Windows, so the example extension (`tests/`) still builds only on Linux and macOS. Windows coverage stops at the unit tests, which is what guards the exec fix.

## References

- [raycast/extensions#28449](https://github.com/raycast/extensions/pull/28449)
