### PR TITLE
Fix useFetch paginated URL factory errors

### DIFF
--- a/src/useFetch.ts
+++ b/src/useFetch.ts
@@ -144,7 +144,16 @@ export function useFetch<V = unknown, U = undefined, T extends unknown[] = unkno
   const mapResultRef = useLatest(mapResult || defaultMapping);
   const urlRef = useRef<RequestInfo | PaginatedRequestInfo>(null);
   const firstPageUrlRef = useRef<RequestInfo | undefined>(null);
-  const firstPageUrl = typeof url === "function" ? url({ page: 0 }) : undefined;
+  const isPaginated = typeof url === "function";
+  let firstPageUrl: RequestInfo | undefined;
+
+  if (isPaginated) {
+    try {
+      firstPageUrl = url({ page: 0 });
+    } catch {
+      // Defer URL factory errors to the paginated fetcher so usePromise can expose them through its error state.
+    }
+  }
   /**
    * When paginating, `url` is a `PaginatedRequestInfo`, so we only want to update the ref when the `firstPageUrl` changes.
    * When not paginating, `url` is a `RequestInfo`, so we want to update the ref whenever `url` changes.
@@ -174,11 +183,11 @@ export function useFetch<V = unknown, U = undefined, T extends unknown[] = unkno
   );
 
   const promise = useMemo(() => {
-    if (firstPageUrlRef.current) {
+    if (isPaginated) {
       return paginatedFn;
     }
     return fn;
-  }, [firstPageUrlRef, fn, paginatedFn]);
+  }, [isPaginated, fn, paginatedFn]);
 
   // @ts-expect-error lastItem can't be inferred properly
   return useCachedPromise(promise, [urlRef.current as PaginatedRequestInfo, fetchOptions], {


### PR DESCRIPTION
## Summary

Fixes a `useFetch` paginated URL factory edge case where the first page URL could be evaluated during render and throw synchronously before `usePromise` had a chance to expose the error through `error` or `onError`.

## Problem

For static URLs, invalid URL errors happen inside the async fetch path and are handled by `usePromise`.

For paginated URL factories, `useFetch` evaluated the first page URL during render to track the first page cache key. If the URL factory threw, the error escaped before the normal async error handling path.

## Changes

- Detect paginated `useFetch` calls with `typeof url === "function"`.
- Avoid letting first page URL computation errors break render.
- Keep paginated calls routed through the paginated fetcher even when first page URL computation fails.
- Defer URL factory errors to the async fetch path so `usePromise` can expose them through its normal error handling.

## Validation

- `npm run lint`
- `npm run build`

Fixes #64