### PR TITLE
runAppleScript: report effective timeout in errors

### DIFF
--- a/docs/utils-reference/getting-started.md
+++ b/docs/utils-reference/getting-started.md
@@ -16,6 +16,10 @@ npm install --save @raycast/utils
 
 ## Changelog
 
+### v2.2.7
+
+- Fixed `runAppleScript` timeout error messages reporting `undefined` instead of the effective timeout.
+
 ### v2.2.6
 
 - Fixed an issue where refreshing OAuth tokens would fails for providers that return scope as an array instead of a string

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@raycast/utils",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@raycast/utils",
-      "version": "2.2.6",
+      "version": "2.2.7",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raycast/utils",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "Set of utilities to streamline building Raycast extensions",
   "author": "Raycast Technologies Ltd.",
   "homepage": "https://developers.raycast.com/utilities/getting-started",

--- a/src/run-applescript.ts
+++ b/src/run-applescript.ts
@@ -103,7 +103,8 @@ export async function runAppleScript<T = string>(
     ...execOptions,
     env: { PATH: "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" },
   });
-  const spawnedPromise = getSpawnedPromise(spawned, { timeout: timeout ?? 10000 });
+  const effectiveTimeout = timeout ?? 10000;
+  const spawnedPromise = getSpawnedPromise(spawned, { timeout: effectiveTimeout });
 
   spawned.stdin.end(script);
 
@@ -123,7 +124,7 @@ export async function runAppleScript<T = string>(
     signal,
     timedOut,
     command: "osascript",
-    options,
+    options: { timeout: effectiveTimeout },
     parentError: new Error(),
   });
 }

--- a/src/run-applescript.ts
+++ b/src/run-applescript.ts
@@ -124,7 +124,12 @@ export async function runAppleScript<T = string>(
     signal,
     timedOut,
     command: "osascript",
-    options: { timeout: effectiveTimeout },
+    options: {
+      humanReadableOutput,
+      language,
+      timeout: effectiveTimeout,
+      ...execOptions,
+    },
     parentError: new Error(),
   });
 }


### PR DESCRIPTION
## Summary

- report the effective timeout in `runAppleScript` timeout errors
- preserve the default 10-second timeout and explicit `timeout: 0`
- bump `@raycast/utils` to 2.2.7 and add a changelog entry

## Root cause

The object-style overload passed the separate third `options` argument to `defaultParsing`. That argument is undefined for calls such as `runAppleScript(script, { timeout: 5000 })`, even though the resolved timeout was correctly passed to the spawned process.

## Testing

- `git diff --check`
- macOS runtime verification for the object overload, arguments overload, default timeout, and `timeout: 0`
- npm lint/build and smoke-extension build could not run locally because the dependency registry was unavailable in the sandbox; GitHub Actions will run the repository checks

Fixes #77
